### PR TITLE
feat: add compilation context to `generate` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Allows filtering the files which make up the manifest. The passed function shoul
 Type: `Function`<br>
 Default: `undefined`
 
-A custom `Function` to create the manifest. The passed function should match the signature of `(seed: Object, files: FileDescriptor[], entries: string[]) => Object` and can return anything as long as it's serialisable by `JSON.stringify`.
+A custom `Function` to create the manifest. The passed function should match the signature of `(seed: Object, files: FileDescriptor[], entries: string[], context: { compilation: Compilation }) => Object` and can return anything as long as it's serialisable by `JSON.stringify`.
 
 ### `map`
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -34,7 +34,7 @@ const generateManifest = (
       (e, [name, entrypoint]) => Object.assign(e, { [name]: entrypoint.getFiles() }),
       {} as Record<string, any>
     );
-    result = generate(seed, files, entrypoints);
+    result = generate(seed, files, entrypoints, { compilation });
   } else {
     result = files.reduce(
       (manifest, file) => Object.assign(manifest, { [file.name]: file.path }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ export interface InternalOptions {
   generate: (
     seed: Record<any, any>,
     files: FileDescriptor[],
-    entries: Record<string, string[]>
+    entries: Record<string, string[]>,
+    context: { compilation: Compilation }
   ) => Manifest;
   map: (file: FileDescriptor) => FileDescriptor;
   publicPath: string;


### PR DESCRIPTION
## Summary

Pass `compilation` context to `generate` function to enable access to compilation-specific data during manifest generation. 
