### PR TITLE
refactor: use `node:` protocol and type imports

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,8 +1,6 @@
-import { dirname, join, basename } from 'path';
-
-import { AssetInfo, Chunk, Asset, Compilation } from '@rspack/core';
-
-import { InternalOptions, Manifest } from './';
+import { dirname, join, basename } from 'node:path';
+import type { AssetInfo, Chunk, Asset, Compilation } from '@rspack/core';
+import type { InternalOptions, Manifest } from './';
 
 export interface FileDescriptor {
   chunk?: Chunk;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,10 +1,8 @@
-import { mkdirSync, writeFileSync } from 'fs';
-import { basename, dirname, join } from 'path';
-
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import { SyncWaterfallHook } from '@rspack/lite-tapable';
-import { Compiler, Module, Compilation, LoaderContext } from '@rspack/core';
-
-import { EmitCountMap, InternalOptions } from './';
+import type { Compiler, Module, Compilation, LoaderContext } from '@rspack/core';
+import type { EmitCountMap, InternalOptions } from './';
 
 import {
   CompilationAsset,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
-import { relative, resolve } from 'path';
-
+import { relative, resolve } from 'node:path';
 import { SyncHook } from '@rspack/lite-tapable';
 import type { Compiler, RspackPluginInstance, Compilation } from '@rspack/core';
-
 import { FileDescriptor } from './helpers';
 import { beforeRunHook, emitHook, getCompilerHooks } from './hooks';
 


### PR DESCRIPTION
## Summary

Standardize imports to use `node:` protocol for core modules and add type imports where applicable.