### PR TITLE
fix: support `publicPath: 'auto'`

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -81,7 +81,13 @@ const emitHook = function emit(
     publicPath: true
   });
 
-  const publicPath = options.publicPath !== null ? options.publicPath : stats.publicPath;
+  // Rspack supports `output.publicPath: 'auto'`, which resolves the publicPath
+  // at runtime based on the current script/asset location. In that mode, the
+  // string value 'auto' should not be serialized into the manifest. Treat it as
+  // an "unset" publicPath so manifest values remain unprefixed and consumers can
+  // resolve at runtime. See https://rspack.rs/guide/features/asset-base-path#automatic-publicpath
+  const resolvedPublicPath = options.publicPath !== null ? options.publicPath : stats.publicPath;
+  const publicPath = resolvedPublicPath === 'auto' ? '' : resolvedPublicPath;
   const { basePath, removeKeyHash } = options;
 
   emitCountMap.set(manifestFileName, emitCount);

--- a/test/unit/paths.js
+++ b/test/unit/paths.js
@@ -72,6 +72,70 @@ test('prefixes paths with a public path', async (t) => {
   });
 });
 
+test("does not prefix paths when webpack's publicPath is 'auto'", async (t) => {
+  const config = {
+    context: __dirname,
+    entry: {
+      one: '../fixtures/file.js'
+    },
+    output: {
+      filename: `[name].${hashLiteral}.js`,
+      path: join(outputPath, 'public-auto'),
+      // Webpack will resolve the publicPath at runtime; the manifest should not contain 'auto'.
+      publicPath: 'auto'
+    }
+  };
+  const { manifest, stats } = await compile(config, t);
+
+  t.deepEqual(manifest, {
+    'one.js': `one.${stats.hash}.js`
+  });
+});
+
+test("prefixes definitions with a base path when webpack's publicPath is 'auto'", async (t) => {
+  const config = {
+    context: __dirname,
+    entry: {
+      one: '../fixtures/file.js'
+    },
+    output: {
+      filename: `[name].${hashLiteral}.js`,
+      path: join(outputPath, 'public-auto-with-basePath'),
+      publicPath: 'auto'
+    }
+  };
+
+  const { manifest, stats } = await compile(config, t, {
+    basePath: '/app/'
+  });
+
+  t.deepEqual(manifest, {
+    '/app/one.js': `one.${stats.hash}.js`
+  });
+});
+
+test("uses plugin 'publicPath' override when webpack's publicPath is 'auto'", async (t) => {
+  const config = {
+    context: __dirname,
+    entry: {
+      one: '../fixtures/file.js'
+    },
+    output: {
+      filename: `[name].${hashLiteral}.js`,
+      path: join(outputPath, 'public-auto-with-override'),
+      publicPath: 'auto'
+    }
+  };
+
+  const { manifest, stats } = await compile(config, t, {
+    publicPath: '/cdn/'
+  });
+
+  t.deepEqual(manifest, {
+    'one.js': `/cdn/one.${stats.hash}.js`
+  });
+});
+
 test(`prefixes paths with a public path and handle ${hashLiteral} from public path`, async (t) => {
   const config = {
     context: __dirname,


### PR DESCRIPTION
## Summary

Ported from upstream PR https://github.com/shellscape/webpack-manifest-plugin/pull/312

Thanks to the original author for the work.