### PR TITLE
fix: update peerDependencies version for @rspack/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "@rspack/core": "0.x || 1.x"
+    "@rspack/core": "^1.0.0 || ^2.0.0-0"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {


### PR DESCRIPTION
Updated the `@rspack/core` peer dependency version range to `^1.0.0 || ^2.0.0-0` in `package.json` to support both stable and prerelease versions of v2.