### PR TITLE
chore: upgrade TypeScript to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "style-loader": "^0.23.0",
     "ts-node": "^10.1.0",
     "tslib": "^2.3.0",
-    "typescript": "^4.9.4",
+    "typescript": "^6.0.2",
     "webpack": "^5.75.0",
     "webpack-merge": "^5.8.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 6.1.1
       eslint-config-shellscape:
         specifier: ^6.0.0
-        version: 6.0.0(typescript@4.9.4)
+        version: 6.0.0(typescript@6.0.2)
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.75.0)
@@ -83,13 +83,13 @@ importers:
         version: 0.23.1
       ts-node:
         specifier: ^10.1.0
-        version: 10.9.1(@types/node@16.18.10)(typescript@4.9.4)
+        version: 10.9.1(@types/node@16.18.10)(typescript@6.0.2)
       tslib:
         specifier: ^2.3.0
         version: 2.4.1
       typescript:
-        specifier: ^4.9.4
-        version: 4.9.4
+        specifier: ^6.0.2
+        version: 6.0.2
       webpack:
         specifier: ^5.75.0
         version: 5.75.0
@@ -3491,6 +3491,11 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
@@ -4841,41 +4846,41 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4))(eslint@8.27.0)(typescript@4.9.4)':
+  '@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2))(eslint@8.27.0)(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 5.46.1
-      '@typescript-eslint/type-utils': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
-      '@typescript-eslint/utils': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
+      '@typescript-eslint/type-utils': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
+      '@typescript-eslint/utils': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
       debug: 4.3.4
       eslint: 8.27.0
       ignore: 5.2.3
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.4)
+      tsutils: 3.21.0(typescript@6.0.2)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/experimental-utils@5.46.1(eslint@8.27.0)(typescript@4.9.4)':
+  '@typescript-eslint/experimental-utils@5.46.1(eslint@8.27.0)(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/utils': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
+      '@typescript-eslint/utils': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
       eslint: 8.27.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4)':
+  '@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.46.1
       '@typescript-eslint/types': 5.46.1
-      '@typescript-eslint/typescript-estree': 5.46.1(typescript@4.9.4)
+      '@typescript-eslint/typescript-estree': 5.46.1(typescript@6.0.2)
       debug: 4.3.4
       eslint: 8.27.0
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4884,21 +4889,21 @@ snapshots:
       '@typescript-eslint/types': 5.46.1
       '@typescript-eslint/visitor-keys': 5.46.1
 
-  '@typescript-eslint/type-utils@5.46.1(eslint@8.27.0)(typescript@4.9.4)':
+  '@typescript-eslint/type-utils@5.46.1(eslint@8.27.0)(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.46.1(typescript@4.9.4)
-      '@typescript-eslint/utils': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
+      '@typescript-eslint/typescript-estree': 5.46.1(typescript@6.0.2)
+      '@typescript-eslint/utils': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
       debug: 4.3.4
       eslint: 8.27.0
-      tsutils: 3.21.0(typescript@4.9.4)
+      tsutils: 3.21.0(typescript@6.0.2)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@5.46.1': {}
 
-  '@typescript-eslint/typescript-estree@5.46.1(typescript@4.9.4)':
+  '@typescript-eslint/typescript-estree@5.46.1(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 5.46.1
       '@typescript-eslint/visitor-keys': 5.46.1
@@ -4906,19 +4911,19 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.4)
+      tsutils: 3.21.0(typescript@6.0.2)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.46.1(eslint@8.27.0)(typescript@4.9.4)':
+  '@typescript-eslint/utils@5.46.1(eslint@8.27.0)(typescript@6.0.2)':
     dependencies:
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.46.1
       '@typescript-eslint/types': 5.46.1
-      '@typescript-eslint/typescript-estree': 5.46.1(typescript@4.9.4)
+      '@typescript-eslint/typescript-estree': 5.46.1(typescript@6.0.2)
       eslint: 8.27.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.27.0)
@@ -5776,14 +5781,14 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-shellscape@6.0.0(typescript@4.9.4):
+  eslint-config-shellscape@6.0.0(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4))(eslint@8.27.0)(typescript@4.9.4)
-      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
+      '@typescript-eslint/eslint-plugin': 5.46.1(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2))(eslint@8.27.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
       eslint: 8.27.0
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4))(eslint@8.27.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2))(eslint@8.27.0)
       eslint-plugin-prettier: 4.2.1(eslint@8.27.0)(prettier@2.8.1)
-      eslint-plugin-typescript-sort-keys: 2.1.0(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4))(eslint@8.27.0)(typescript@4.9.4)
+      eslint-plugin-typescript-sort-keys: 2.1.0(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2))(eslint@8.27.0)(typescript@6.0.2)
       prettier: 2.8.1
       prettier-plugin-package: 1.3.0(prettier@2.8.1)
     transitivePeerDependencies:
@@ -5800,17 +5805,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.7.4(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.6)(eslint@8.27.0):
+  eslint-module-utils@2.7.4(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.6)(eslint@8.27.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
       eslint: 8.27.0
       eslint-import-resolver-node: 0.3.6
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4))(eslint@8.27.0):
+  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2))(eslint@8.27.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
@@ -5818,7 +5823,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.27.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.6)(eslint@8.27.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.6)(eslint@8.27.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -5827,7 +5832,7 @@ snapshots:
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
     optionalDependencies:
-      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -5839,14 +5844,14 @@ snapshots:
       prettier: 2.8.1
       prettier-linter-helpers: 1.0.0
 
-  eslint-plugin-typescript-sort-keys@2.1.0(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@4.9.4))(eslint@8.27.0)(typescript@4.9.4):
+  eslint-plugin-typescript-sort-keys@2.1.0(@typescript-eslint/parser@5.46.1(eslint@8.27.0)(typescript@6.0.2))(eslint@8.27.0)(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
-      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@4.9.4)
+      '@typescript-eslint/experimental-utils': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 5.46.1(eslint@8.27.0)(typescript@6.0.2)
       eslint: 8.27.0
       json-schema: 0.4.0
       natural-compare-lite: 1.4.0
-      typescript: 4.9.4
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7463,7 +7468,7 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-node@10.9.1(@types/node@16.18.10)(typescript@4.9.4):
+  ts-node@10.9.1(@types/node@16.18.10)(typescript@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -7477,7 +7482,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.4
+      typescript: 6.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -7502,10 +7507,10 @@ snapshots:
 
   tslib@2.4.1: {}
 
-  tsutils@3.21.0(typescript@4.9.4):
+  tsutils@3.21.0(typescript@6.0.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.4
+      typescript: 6.0.2
 
   type-check@0.4.0:
     dependencies:
@@ -7532,6 +7537,8 @@ snapshots:
   typedarray@0.0.6: {}
 
   typescript@4.9.4: {}
+
+  typescript@6.0.2: {}
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,15 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "target": "ES2023",
+    "types": ["node"],
+    "lib": ["DOM", "ESNext"],
+    "declaration": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
   },
-  "extends": "./tsconfig.base.json",
   "include": ["src"]
 }


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

None

### Description

Upgrade TypeScript to ^6.0.2, replace the root tsconfig with the shared NodeNext configuration, and validate the change with `pnpm build` and `pnpm test`.