### PR TITLE
chore: update peer dependency range

### DIFF
--- a/.github/workflows/node-windows.yml
+++ b/.github/workflows/node-windows.yml
@@ -24,13 +24,13 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout Commit
-        uses: actions/checkout@v1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Checkout Master
         run: git branch -f master origin/master
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/node-windows.yml
+++ b/.github/workflows/node-windows.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Checkout Commit
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          fetch-depth: 0
 
       - name: Checkout Master
         run: git branch -f master origin/master

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Check PR Title
-        uses: clowdhaus/actions/pr-title@v0.1.0
+        uses: clowdhaus/actions/pr-title@a24002da5d4dc10f402f5f0739da2f519cbc70f9
         with:
           on-fail-message: "Your PR title doesn't match the required format. The title should be in the conventional commit (https://www.conventionalcommits.org/en/v1.0.0-beta.4/) format. e.g.\n\n```\nchore(plugin-name): add pr title workflow\n```"
           title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w|,|\-|\|]+\))?(!)?\:\s.*$'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
     environment: npm
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24.11.0
 
@@ -39,11 +39,11 @@ jobs:
         run: pnpm install && pnpm build
 
       - name: Publish
-        uses: JS-DevTools/npm-publish@v4
+        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f
         with:
           token: empty
 
       - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
           generateReleaseNotes: "true"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout Commit
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "@rspack/core": "^1.0.0 || ^2.0.0-0"
+    "@rspack/core": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

Update the `@rspack/core` peer dependency range from the prerelease 2.0 floor (`^2.0.0-0`) to the stable 2.x range (`^2.0.0`). This is a package metadata-only change and does not alter runtime behavior.