### PR TITLE
chore: optimize CI pnpm setup

### DIFF
--- a/.github/workflows/node-windows.yml
+++ b/.github/workflows/node-windows.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: ${{ matrix.node }}
+          package-manager-cache: false
 
-      - name: install pnpm
-        run: npm install pnpm -g
-
-      - name: pnpm install
-        run: pnpm install --ignore-scripts
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: true
 
       - name: run tests
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.15.0
+          package-manager-cache: false
 
-      - name: Setup Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
-      - name: Install Dependencies
-        run: pnpm i
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: true
 
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,12 +30,10 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: ${{ matrix.node }}
+          package-manager-cache: false
 
       - name: Checkout Master
         run: git branch -f master origin/master
-
-      - name: Install pnpm
-        run: npm install pnpm -g
 
       - name: Sanity Check
         run: |
@@ -43,8 +41,10 @@ jobs:
           echo node `node --version`;
           echo yarn `pnpm --version`
 
-      - name: pnpm install
-        run: pnpm install
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: true
 
       - name: Audit Dependencies
         run: pnpm security

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Checkout Master
         run: git branch -f master origin/master
 
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: true
+
       - name: Sanity Check
         run: |
           echo branch `git branch --show-current`;
           echo node `node --version`;
           echo yarn `pnpm --version`
-
-      - name: Install Pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          run_install: true
 
       - name: Audit Dependencies
         run: pnpm security


### PR DESCRIPTION
## Summary

This PR aligns the GitHub Actions pnpm setup with the current Rsbuild workflow pattern from https://github.com/web-infra-dev/rsbuild/pull/7856.

- Replace corepack/manual pnpm install steps with `pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093` and `run_install: true`.
- Explicitly disable `actions/setup-node` package manager caching with `package-manager-cache: false`.
- Keep browser installation commands as separate post-install steps where needed.